### PR TITLE
Batch Creation and Deletion of Waypoints

### DIFF
--- a/controllers/waypoint_controller.go
+++ b/controllers/waypoint_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"errors"
+	"fmt"
 	"gcom-backend/models"
 	"gcom-backend/responses"
 	"net/http"
@@ -77,63 +78,50 @@ func CreateWaypoint(c echo.Context) error {
 
 // CreateWaypointBatch creates multiple waypoints
 //
-//	@Summary		Create multiple waypoint
-//	@Description	Create multiple waypoints based on JSON, must have sentinel ID of "-1"
-//	@Tags			Waypoint
+//	@Summary		Create multiple waypoints
+//	@Description	Create multiple waypoints based on JSON, all must have sentinel ID of "-1"
+//	@Tags			[]Waypoint
 //	@Accept			json
 //	@Produce		json
-//	@Param			waypoint	body		models.Waypoint				true	"Waypoint Data"
+//	@Param			waypoints	body		[]models.Waypoint			true	"Waypoints Data"
 //	@Success		200			{object}	responses.WaypointResponse	"Success"
 //	@Failure		400			{object}	responses.ErrorResponse		"Invalid JSON or Waypoint Data"
 //	@Failure		500			{object}	responses.ErrorResponse		"Internal Error Creating Waypoint"
-//	@Router			/waypoint [post]
+//	@Router			/waypoints [post]
 func CreateWaypointBatch(c echo.Context) error {
-	var waypoints []models.Waypoint //Declares an empty Waypoint class
-	db, _ := c.Get("db").(*gorm.DB) //Obtains the DB instance from the context
+	var waypoints []models.Waypoint
+	db, _ := c.Get("db").(*gorm.DB)
 
 	if err := c.Bind(&waypoints); err != nil {
-		/*
-			.Bind() basically tries to force the JSON data provided into the
-			struct, using the json:"field" annotations we added to know what
-			goes where. c.Bind directly edits the waypoint variable and as such
-			we provide the memory address of it using the & symbol in front.
-			c.Bind returns an error if something goes wrong, and we catch it here
-			by checking if it is nil
-		*/
 		return c.JSON(http.StatusBadRequest, responses.ErrorResponse{
 			Message: "Invalid JSON format",
 			Data:    err.Error()})
 	}
 
 	if validationErr := validate.Struct(&waypoints); validationErr != nil {
-		/*
-			validate.Struct() validates the struct based on the validate
-			annotation we provided in the struct definition
-		*/
 		return c.JSON(http.StatusBadRequest, responses.ErrorResponse{
-			Message: "Invalid waypoint data",
+			Message: "Invalid waypoints data",
 			Data:    validationErr.Error()})
 	}
 
-	if waypoints.ID != -1 {
-		return c.JSON(http.StatusBadRequest, responses.ErrorResponse{
-			Message: "Non-sentinel ID passed"})
-	} else {
-		waypoints.ID = 0
+	for i := 0; i < len(waypoints); i++ {
+		if waypoints[i].ID != -1 {
+			return c.JSON(http.StatusBadRequest, responses.ErrorResponse{
+				Message: fmt.Sprintf("Non-sentinel ID passed for waypoint %d", i)})
+		} else {
+			waypoints[i].ID = 0
+		}
+
 	}
 
 	if createErr := db.Create(&waypoints).Error; createErr != nil {
-		/*
-			Here we use GROM functions. GROM has already created tables for the
-			model definitions we provided and knows what type `waypoint` is
-		*/
 		return c.JSON(http.StatusInternalServerError, responses.ErrorResponse{
-			Message: "An error occurred creating the waypoint"})
+			Message: "An error occurred creating the waypoints"})
 	}
 
-	return c.JSON(http.StatusOK, responses.WaypointResponse{
-		Message:  "Waypoint Created!",
-		Waypoint: waypoints})
+	return c.JSON(http.StatusOK, responses.WaypointsResponse{
+		Message:   "Waypoints Created!",
+		Waypoints: waypoints})
 }
 
 // EditWaypoint edits a waypoint

--- a/controllers/waypoint_controller.go
+++ b/controllers/waypoint_controller.go
@@ -98,13 +98,12 @@ func CreateWaypointBatch(c echo.Context) error {
 			Data:    err.Error()})
 	}
 
-	if validationErr := validate.Struct(&waypoints); validationErr != nil {
-		return c.JSON(http.StatusBadRequest, responses.ErrorResponse{
-			Message: "Invalid waypoints data",
-			Data:    validationErr.Error()})
-	}
-
 	for i := 0; i < len(waypoints); i++ {
+		if validationErr := validate.Struct(&(waypoints[i])); validationErr != nil {
+			return c.JSON(http.StatusBadRequest, responses.ErrorResponse{
+				Message: "Invalid waypoints data",
+				Data:    validationErr.Error()})
+		}
 		if waypoints[i].ID != -1 {
 			return c.JSON(http.StatusBadRequest, responses.ErrorResponse{
 				Message: fmt.Sprintf("Non-sentinel ID passed for waypoint %d", i)})

--- a/controllers/waypoint_controller.go
+++ b/controllers/waypoint_controller.go
@@ -80,11 +80,11 @@ func CreateWaypoint(c echo.Context) error {
 //
 //	@Summary		Create multiple waypoints
 //	@Description	Create multiple waypoints based on JSON, all must have sentinel ID of "-1"
-//	@Tags			[]Waypoint
+//	@Tags			Waypoint
 //	@Accept			json
 //	@Produce		json
-//	@Param			waypoints	body		[]models.Waypoint			true	"Waypoints Data"
-//	@Success		200			{object}	responses.WaypointResponse	"Success"
+//	@Param			waypoints	body		[]models.Waypoint			true		"Array of Waypoint Data"
+//	@Success		200			{object}	responses.WaypointsResponse	"Success"
 //	@Failure		400			{object}	responses.ErrorResponse		"Invalid JSON or Waypoint Data"
 //	@Failure		500			{object}	responses.ErrorResponse		"Internal Error Creating Waypoint"
 //	@Router			/waypoints [post]

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -25,6 +25,49 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/status": {
+            "get": {
+                "description": "Get the current status of the drone",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Drone"
+                ],
+                "summary": "Get drone status",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/models.Drone"
+                        }
+                    }
+                }
+            }
+        },
+        "/status/history": {
+            "get": {
+                "description": "Get drone status for the last 5 minutes",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Drone"
+                ],
+                "summary": "Get drone status history",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Drone"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/waypoint": {
             "post": {
                 "description": "Create a singular waypoint based on JSON, must have sentinel ID of \"-1\"",
@@ -40,7 +83,7 @@ const docTemplate = `{
                 "summary": "Create a waypoint",
                 "parameters": [
                     {
-                        "description": "Waypoint Data",
+                        "description": "Waypoint data.",
                         "name": "waypoint",
                         "in": "body",
                         "required": true,
@@ -242,6 +285,53 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "post": {
+                "description": "Create multiple waypoints based on JSON, all must have sentinel ID of \"-1\"",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Waypoint"
+                ],
+                "summary": "Create multiple waypoints",
+                "parameters": [
+                    {
+                        "description": "Array of Waypoint Data",
+                        "name": "waypoints",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Waypoint"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/responses.WaypointsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid JSON or Waypoint Data",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Error Creating Waypoint",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
             }
         }
     },
@@ -261,6 +351,63 @@ const docTemplate = `{
                 "Obstacle",
                 "Payload"
             ]
+        },
+        "models.Drone": {
+            "description": "describes the drone being flown",
+            "type": "object",
+            "required": [
+                "alt",
+                "battery_voltage",
+                "heading",
+                "lat",
+                "long",
+                "speed",
+                "timestamp",
+                "v_speed"
+            ],
+            "properties": {
+                "timestamp": {
+                    "type": "integer",
+                    "x-order": "1",
+                    "example": 1698544781
+                },
+                "lat": {
+                    "type": "number",
+                    "x-order": "2",
+                    "example": 49.267941
+                },
+                "long": {
+                    "type": "number",
+                    "x-order": "3",
+                    "example": -123.24736
+                },
+                "alt": {
+                    "type": "number",
+                    "x-order": "4",
+                    "example": 100
+                },
+                "v_speed": {
+                    "type": "number",
+                    "x-order": "5",
+                    "example": -1.63
+                },
+                "speed": {
+                    "type": "number",
+                    "x-order": "6",
+                    "example": 0.98
+                },
+                "heading": {
+                    "type": "number",
+                    "x-order": "7",
+                    "example": 298.12
+                },
+                "battery_voltage": {
+                    "description": "Payloads TBD",
+                    "type": "number",
+                    "x-order": "9",
+                    "example": 2.6
+                }
+            }
         },
         "models.Waypoint": {
             "description": "describes a location in GCOM",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -83,7 +83,7 @@ const docTemplate = `{
                 "summary": "Create a waypoint",
                 "parameters": [
                     {
-                        "description": "Waypoint data.",
+                        "description": "Waypoint Data",
                         "name": "waypoint",
                         "in": "body",
                         "required": true,
@@ -332,6 +332,56 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "delete": {
+                "description": "Delete multiple waypoints based on json body",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Waypoint"
+                ],
+                "summary": "Delete multiple waypoints",
+                "parameters": [
+                    {
+                        "description": "Waypoint IDs",
+                        "name": "id",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.WaypointIDs"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success (returns a blank Waypoint)",
+                        "schema": {
+                            "$ref": "#/definitions/responses.WaypointResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid JSON or Waypoint IDs",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Waypoints Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Error Deleting Waypoint",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
             }
         }
     },
@@ -466,6 +516,23 @@ const docTemplate = `{
                     "type": "string",
                     "x-order": "8",
                     "example": "Task 1 Landing Zone"
+                }
+            }
+        },
+        "models.WaypointIDs": {
+            "type": "object",
+            "properties": {
+                "ids": {
+                    "description": "IDs is an array of strings because idk how to implement\n\t\tcustom unmarshalling of the json strings into ints.\n\t\tI have chosen to simply convert the strings to integers\n\t\tin the route function in waypoint_controller.go (see DeleteWaypointBatch())s\n\t\tPlease lmk if there is a way to do this in the unmarshalling process\n\t\tinstead of the actual route.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "1",
+                        "2",
+                        "3"
+                    ]
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -348,11 +348,14 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "description": "Waypoint IDs",
-                        "name": "id",
+                        "name": "ids",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.WaypointIDs"
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
                         }
                     }
                 ],
@@ -516,23 +519,6 @@ const docTemplate = `{
                     "type": "string",
                     "x-order": "8",
                     "example": "Task 1 Landing Zone"
-                }
-            }
-        },
-        "models.WaypointIDs": {
-            "type": "object",
-            "properties": {
-                "ids": {
-                    "description": "IDs is an array of strings because idk how to implement\n\t\tcustom unmarshalling of the json strings into ints.\n\t\tI have chosen to simply convert the strings to integers\n\t\tin the route function in waypoint_controller.go (see DeleteWaypointBatch())s\n\t\tPlease lmk if there is a way to do this in the unmarshalling process\n\t\tinstead of the actual route.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "example": [
-                        "1",
-                        "2",
-                        "3"
-                    ]
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -341,11 +341,14 @@
                 "parameters": [
                     {
                         "description": "Waypoint IDs",
-                        "name": "id",
+                        "name": "ids",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.WaypointIDs"
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
                         }
                     }
                 ],
@@ -509,23 +512,6 @@
                     "type": "string",
                     "x-order": "8",
                     "example": "Task 1 Landing Zone"
-                }
-            }
-        },
-        "models.WaypointIDs": {
-            "type": "object",
-            "properties": {
-                "ids": {
-                    "description": "IDs is an array of strings because idk how to implement\n\t\tcustom unmarshalling of the json strings into ints.\n\t\tI have chosen to simply convert the strings to integers\n\t\tin the route function in waypoint_controller.go (see DeleteWaypointBatch())s\n\t\tPlease lmk if there is a way to do this in the unmarshalling process\n\t\tinstead of the actual route.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "example": [
-                        "1",
-                        "2",
-                        "3"
-                    ]
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -76,7 +76,7 @@
                 "summary": "Create a waypoint",
                 "parameters": [
                     {
-                        "description": "Waypoint data.",
+                        "description": "Waypoint Data",
                         "name": "waypoint",
                         "in": "body",
                         "required": true,
@@ -325,6 +325,56 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "description": "Delete multiple waypoints based on json body",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Waypoint"
+                ],
+                "summary": "Delete multiple waypoints",
+                "parameters": [
+                    {
+                        "description": "Waypoint IDs",
+                        "name": "id",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.WaypointIDs"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success (returns a blank Waypoint)",
+                        "schema": {
+                            "$ref": "#/definitions/responses.WaypointResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid JSON or Waypoint IDs",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Waypoints Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Error Deleting Waypoint",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
             }
         }
     },
@@ -459,6 +509,23 @@
                     "type": "string",
                     "x-order": "8",
                     "example": "Task 1 Landing Zone"
+                }
+            }
+        },
+        "models.WaypointIDs": {
+            "type": "object",
+            "properties": {
+                "ids": {
+                    "description": "IDs is an array of strings because idk how to implement\n\t\tcustom unmarshalling of the json strings into ints.\n\t\tI have chosen to simply convert the strings to integers\n\t\tin the route function in waypoint_controller.go (see DeleteWaypointBatch())s\n\t\tPlease lmk if there is a way to do this in the unmarshalling process\n\t\tinstead of the actual route.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "1",
+                        "2",
+                        "3"
+                    ]
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -18,6 +18,49 @@
     },
     "host": "localhost:1323",
     "paths": {
+        "/status": {
+            "get": {
+                "description": "Get the current status of the drone",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Drone"
+                ],
+                "summary": "Get drone status",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/models.Drone"
+                        }
+                    }
+                }
+            }
+        },
+        "/status/history": {
+            "get": {
+                "description": "Get drone status for the last 5 minutes",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Drone"
+                ],
+                "summary": "Get drone status history",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Drone"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/waypoint": {
             "post": {
                 "description": "Create a singular waypoint based on JSON, must have sentinel ID of \"-1\"",
@@ -33,7 +76,7 @@
                 "summary": "Create a waypoint",
                 "parameters": [
                     {
-                        "description": "Waypoint Data",
+                        "description": "Waypoint data.",
                         "name": "waypoint",
                         "in": "body",
                         "required": true,
@@ -235,6 +278,53 @@
                         }
                     }
                 }
+            },
+            "post": {
+                "description": "Create multiple waypoints based on JSON, all must have sentinel ID of \"-1\"",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Waypoint"
+                ],
+                "summary": "Create multiple waypoints",
+                "parameters": [
+                    {
+                        "description": "Array of Waypoint Data",
+                        "name": "waypoints",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Waypoint"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/responses.WaypointsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid JSON or Waypoint Data",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Error Creating Waypoint",
+                        "schema": {
+                            "$ref": "#/definitions/responses.ErrorResponse"
+                        }
+                    }
+                }
             }
         }
     },
@@ -254,6 +344,63 @@
                 "Obstacle",
                 "Payload"
             ]
+        },
+        "models.Drone": {
+            "description": "describes the drone being flown",
+            "type": "object",
+            "required": [
+                "alt",
+                "battery_voltage",
+                "heading",
+                "lat",
+                "long",
+                "speed",
+                "timestamp",
+                "v_speed"
+            ],
+            "properties": {
+                "timestamp": {
+                    "type": "integer",
+                    "x-order": "1",
+                    "example": 1698544781
+                },
+                "lat": {
+                    "type": "number",
+                    "x-order": "2",
+                    "example": 49.267941
+                },
+                "long": {
+                    "type": "number",
+                    "x-order": "3",
+                    "example": -123.24736
+                },
+                "alt": {
+                    "type": "number",
+                    "x-order": "4",
+                    "example": 100
+                },
+                "v_speed": {
+                    "type": "number",
+                    "x-order": "5",
+                    "example": -1.63
+                },
+                "speed": {
+                    "type": "number",
+                    "x-order": "6",
+                    "example": 0.98
+                },
+                "heading": {
+                    "type": "number",
+                    "x-order": "7",
+                    "example": 298.12
+                },
+                "battery_voltage": {
+                    "description": "Payloads TBD",
+                    "type": "number",
+                    "x-order": "9",
+                    "example": 2.6
+                }
+            }
         },
         "models.Waypoint": {
             "description": "describes a location in GCOM",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -14,6 +14,52 @@ definitions:
     - Land
     - Obstacle
     - Payload
+  models.Drone:
+    description: describes the drone being flown
+    properties:
+      alt:
+        example: 100
+        type: number
+        x-order: "4"
+      battery_voltage:
+        description: Payloads TBD
+        example: 2.6
+        type: number
+        x-order: "9"
+      heading:
+        example: 298.12
+        type: number
+        x-order: "7"
+      lat:
+        example: 49.267941
+        type: number
+        x-order: "2"
+      long:
+        example: -123.24736
+        type: number
+        x-order: "3"
+      speed:
+        example: 0.98
+        type: number
+        x-order: "6"
+      timestamp:
+        example: 1698544781
+        type: integer
+        x-order: "1"
+      v_speed:
+        example: -1.63
+        type: number
+        x-order: "5"
+    required:
+    - alt
+    - battery_voltage
+    - heading
+    - lat
+    - long
+    - speed
+    - timestamp
+    - v_speed
+    type: object
   models.Waypoint:
     description: describes a location in GCOM
     properties:
@@ -99,6 +145,34 @@ info:
   title: GCOM Backend
   version: "1.0"
 paths:
+  /status:
+    get:
+      description: Get the current status of the drone
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: '#/definitions/models.Drone'
+      summary: Get drone status
+      tags:
+      - Drone
+  /status/history:
+    get:
+      description: Get drone status for the last 5 minutes
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Success
+          schema:
+            items:
+              $ref: '#/definitions/models.Drone'
+            type: array
+      summary: Get drone status history
+      tags:
+      - Drone
   /waypoint:
     post:
       consumes:
@@ -106,7 +180,7 @@ paths:
       description: Create a singular waypoint based on JSON, must have sentinel ID
         of "-1"
       parameters:
-      - description: Waypoint Data
+      - description: Waypoint data.
         in: body
         name: waypoint
         required: true
@@ -243,6 +317,38 @@ paths:
           schema:
             $ref: '#/definitions/responses.ErrorResponse'
       summary: Get all waypoints
+      tags:
+      - Waypoint
+    post:
+      consumes:
+      - application/json
+      description: Create multiple waypoints based on JSON, all must have sentinel
+        ID of "-1"
+      parameters:
+      - description: Array of Waypoint Data
+        in: body
+        name: waypoints
+        required: true
+        schema:
+          items:
+            $ref: '#/definitions/models.Waypoint'
+          type: array
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: '#/definitions/responses.WaypointsResponse'
+        "400":
+          description: Invalid JSON or Waypoint Data
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+        "500":
+          description: Internal Error Creating Waypoint
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+      summary: Create multiple waypoints
       tags:
       - Waypoint
 produces:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -106,6 +106,22 @@ definitions:
     - long
     - name
     type: object
+  models.WaypointIDs:
+    properties:
+      ids:
+        description: "IDs is an array of strings because idk how to implement\n\t\tcustom
+          unmarshalling of the json strings into ints.\n\t\tI have chosen to simply
+          convert the strings to integers\n\t\tin the route function in waypoint_controller.go
+          (see DeleteWaypointBatch())s\n\t\tPlease lmk if there is a way to do this
+          in the unmarshalling process\n\t\tinstead of the actual route."
+        example:
+        - "1"
+        - "2"
+        - "3"
+        items:
+          type: string
+        type: array
+    type: object
   responses.ErrorResponse:
     description: JSON response for any error
     properties:
@@ -180,7 +196,7 @@ paths:
       description: Create a singular waypoint based on JSON, must have sentinel ID
         of "-1"
       parameters:
-      - description: Waypoint data.
+      - description: Waypoint Data
         in: body
         name: waypoint
         required: true
@@ -301,6 +317,39 @@ paths:
       tags:
       - Waypoint
   /waypoints:
+    delete:
+      consumes:
+      - application/json
+      description: Delete multiple waypoints based on json body
+      parameters:
+      - description: Waypoint IDs
+        in: body
+        name: id
+        required: true
+        schema:
+          $ref: '#/definitions/models.WaypointIDs'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Success (returns a blank Waypoint)
+          schema:
+            $ref: '#/definitions/responses.WaypointResponse'
+        "400":
+          description: Invalid JSON or Waypoint IDs
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+        "404":
+          description: Waypoints Not Found
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+        "500":
+          description: Internal Error Deleting Waypoint
+          schema:
+            $ref: '#/definitions/responses.ErrorResponse'
+      summary: Delete multiple waypoints
+      tags:
+      - Waypoint
     get:
       consumes:
       - application/json

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -106,22 +106,6 @@ definitions:
     - long
     - name
     type: object
-  models.WaypointIDs:
-    properties:
-      ids:
-        description: "IDs is an array of strings because idk how to implement\n\t\tcustom
-          unmarshalling of the json strings into ints.\n\t\tI have chosen to simply
-          convert the strings to integers\n\t\tin the route function in waypoint_controller.go
-          (see DeleteWaypointBatch())s\n\t\tPlease lmk if there is a way to do this
-          in the unmarshalling process\n\t\tinstead of the actual route."
-        example:
-        - "1"
-        - "2"
-        - "3"
-        items:
-          type: string
-        type: array
-    type: object
   responses.ErrorResponse:
     description: JSON response for any error
     properties:
@@ -324,10 +308,12 @@ paths:
       parameters:
       - description: Waypoint IDs
         in: body
-        name: id
+        name: ids
         required: true
         schema:
-          $ref: '#/definitions/models.WaypointIDs'
+          items:
+            type: integer
+          type: array
       produces:
       - application/json
       responses:

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"gcom-backend/controllers"
 	_ "gcom-backend/docs"
 	"gcom-backend/util"
+
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	echoSwagger "github.com/swaggo/echo-swagger"
@@ -41,6 +42,7 @@ func main() {
 
 	//Waypoints
 	e.POST("/waypoint", controllers.CreateWaypoint)
+	e.POST("/waypoints", controllers.CreateWaypointBatch)
 	e.PATCH("/waypoint/:waypointId", controllers.EditWaypoint)
 	e.GET("/waypoint/:waypointId", controllers.GetWaypoint)
 	e.DELETE("/waypoint/:waypointId", controllers.DeleteWaypoint)
@@ -53,5 +55,5 @@ func main() {
 	//Websockets
 	e.Any("/socket.io/", controllers.WebsocketHandler())
 
-	e.Logger.Fatal(e.Start(":1323"))
+	e.Logger.Fatal(e.Start("localhost:1323"))
 }

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func main() {
 	e.PATCH("/waypoint/:waypointId", controllers.EditWaypoint)
 	e.GET("/waypoint/:waypointId", controllers.GetWaypoint)
 	e.DELETE("/waypoint/:waypointId", controllers.DeleteWaypoint)
+	e.DELETE("/waypoints", controllers.DeleteWaypointBatch)
 	e.GET("/waypoints", controllers.GetAllWaypoints)
 
 	//Drone

--- a/models/waypoint_model.go
+++ b/models/waypoint_model.go
@@ -28,3 +28,15 @@ type Waypoint struct {
 	Designation Designation `json:"designation,omitempty" example:"land" extensions:"x-order=7"`
 	Remarks     string      `json:"remarks,omitempty" example:"Task 1 Landing Zone" extensions:"x-order=8"`
 }
+
+type WaypointIDs struct {
+	/*
+		IDs is an array of strings because idk how to implement
+		custom unmarshalling of the json strings into ints.
+		I have chosen to simply convert the strings to integers
+		in the route function in waypoint_controller.go (see DeleteWaypointBatch())s
+		Please lmk if there is a way to do this in the unmarshalling process
+		instead of the actual route.
+	*/
+	IDs []string `json:"ids" example:"1,2,3"`
+}

--- a/models/waypoint_model.go
+++ b/models/waypoint_model.go
@@ -28,15 +28,3 @@ type Waypoint struct {
 	Designation Designation `json:"designation,omitempty" example:"land" extensions:"x-order=7"`
 	Remarks     string      `json:"remarks,omitempty" example:"Task 1 Landing Zone" extensions:"x-order=8"`
 }
-
-type WaypointIDs struct {
-	/*
-		IDs is an array of strings because idk how to implement
-		custom unmarshalling of the json strings into ints.
-		I have chosen to simply convert the strings to integers
-		in the route function in waypoint_controller.go (see DeleteWaypointBatch())s
-		Please lmk if there is a way to do this in the unmarshalling process
-		instead of the actual route.
-	*/
-	IDs []string `json:"ids" example:"1,2,3"`
-}


### PR DESCRIPTION
Batch creation and deletion of waypoints now exposed as `POST` and `DEL` endpoints for the `/waypoints` route, with corresponding updated swagger documentation.

Preliminary testing (in Insomnia) has been done to ensure basic functionality, further edge-case tests probably should be done to ensure code strength.

Other small changes:
- capitalization of response messages is more consistent.
- changed server start address to include the `localhost` keyword (without this my firewall acts up, no functional difference with or without otherwise).