### PR TITLE
ODLC Endpoints

### DIFF
--- a/controllers/image_controller.go
+++ b/controllers/image_controller.go
@@ -1,0 +1,71 @@
+package controllers
+
+import (
+	"fmt"
+	"gcom-backend/models"
+	"gcom-backend/responses"
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+)
+
+func UploadImage(c echo.Context) error {
+	file, err := c.FormFile("file")
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, err.Error())
+	}
+
+	src, err := file.Open()
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, err.Error())
+	}
+	defer src.Close()
+
+	match, err := regexp.MatchString("(\\d{10})", file.Filename)
+	if err != nil || !match {
+		return c.JSON(http.StatusBadRequest, "Invalid image name, use UNIX timestamp")
+	}
+	dst, err := os.Create("imgs/" + file.Filename)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, "Error saving image")
+	}
+	defer dst.Close()
+
+	timestamp, _ := strconv.Atoi(file.Filename[:10])
+	fmt.Println(file.Filename[:13])
+	fmt.Println(timestamp)
+	image := &models.Image{
+		Timestamp: int64(timestamp),
+		Filename:  file.Filename,
+	}
+
+	db, _ := c.Get("db").(*gorm.DB)
+	if createErr := db.Create(&image).Error; createErr != nil {
+		return c.JSON(http.StatusInternalServerError, createErr.Error())
+	}
+
+	return c.JSON(http.StatusAccepted, "Upload sucessful")
+}
+
+func ListImages(c echo.Context) error {
+	var images []models.Image
+	db, _ := c.Get("db").(*gorm.DB)
+	if err := db.Find(&images).Error; err != nil {
+		return c.JSON(http.StatusInternalServerError, responses.ErrorResponse{
+			Message: "Error whilst querying waypoints!",
+			Data:    err.Error()})
+	}
+
+	return c.JSON(http.StatusOK, images)
+}
+
+func GetImage(c echo.Context) error {
+	return nil
+}
+
+func GetImageDetails(c echo.Context) error {
+	return nil
+}

--- a/controllers/image_controller.go
+++ b/controllers/image_controller.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"fmt"
 	"gcom-backend/models"
-	"gcom-backend/responses"
 	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
 	"net/http"
@@ -11,6 +10,8 @@ import (
 	"regexp"
 	"strconv"
 )
+
+var imgDirectory = "./imgs/"
 
 func UploadImage(c echo.Context) error {
 	file, err := c.FormFile("file")
@@ -28,7 +29,7 @@ func UploadImage(c echo.Context) error {
 	if err != nil || !match {
 		return c.JSON(http.StatusBadRequest, "Invalid image name, use UNIX timestamp")
 	}
-	dst, err := os.Create("imgs/" + file.Filename)
+	dst, err := os.Create(imgDirectory + file.Filename)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, "Error saving image")
 	}
@@ -54,18 +55,18 @@ func ListImages(c echo.Context) error {
 	var images []models.Image
 	db, _ := c.Get("db").(*gorm.DB)
 	if err := db.Find(&images).Error; err != nil {
-		return c.JSON(http.StatusInternalServerError, responses.ErrorResponse{
-			Message: "Error whilst querying waypoints!",
-			Data:    err.Error()})
+		return c.JSON(http.StatusInternalServerError, err.Error())
 	}
 
 	return c.JSON(http.StatusOK, images)
 }
 
 func GetImage(c echo.Context) error {
-	return nil
-}
-
-func GetImageDetails(c echo.Context) error {
-	return nil
+	imgPath, err := os.Stat(imgDirectory + c.Param("filename"))
+	fmt.Println(imgPath.Name())
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, err.Error())
+	} else {
+		return c.Attachment(imgDirectory+c.Param("filename"), c.Param("filename"))
+	}
 }

--- a/controllers/waypoint_controller.go
+++ b/controllers/waypoint_controller.go
@@ -74,8 +74,8 @@ func CreateWaypoint(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, responses.SingleResponse[models.Waypoint]{
-		Message:  "Waypoint created!",
-		Model: waypoint})
+		Message: "Waypoint created!",
+		Model:   waypoint})
 }
 
 // CreateWaypointBatch creates multiple waypoints
@@ -121,8 +121,8 @@ func CreateWaypointBatch(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, responses.MultipleResponse[models.Waypoint]{
-		Message:   "Waypoints created!",
-		Models: waypoints})
+		Message: "Waypoints created!",
+		Models:  waypoints})
 }
 
 // EditWaypoint edits a waypoint
@@ -199,8 +199,8 @@ func EditWaypoint(c echo.Context) error {
 	db.First(&updatedWaypoint, waypointId)
 
 	return c.JSON(http.StatusOK, responses.SingleResponse[models.Waypoint]{
-		Message:  "Waypoint updated!",
-		Model: updatedWaypoint,
+		Message: "Waypoint updated!",
+		Model:   updatedWaypoint,
 	})
 }
 
@@ -230,8 +230,8 @@ func GetWaypoint(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, responses.SingleResponse[models.Waypoint]{
-		Message:  "Waypoint found!",
-		Model: waypoint,
+		Message: "Waypoint found!",
+		Model:   waypoint,
 	})
 }
 
@@ -267,8 +267,8 @@ func DeleteWaypoint(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, responses.SingleResponse[models.Waypoint]{
-		Message:  "Waypoint deleted!",
-		Model: models.Waypoint{},
+		Message: "Waypoint deleted!",
+		Model:   models.Waypoint{},
 	})
 }
 
@@ -329,8 +329,8 @@ func DeleteWaypointBatch(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, responses.SingleResponse[models.Waypoint]{
-		Message:  "Waypoints deleted!",
-		Model: models.Waypoint{},
+		Message: "Waypoints deleted!",
+		Model:   models.Waypoint{},
 	})
 }
 
@@ -360,7 +360,7 @@ func GetAllWaypoints(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, responses.MultipleResponse[models.Waypoint]{
-		Message:   "Waypoint found!",
-		Models: waypoints,
+		Message: "Images found!",
+		Models:  waypoints,
 	})
 }

--- a/main.go
+++ b/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"gcom-backend/configs"
 	"gcom-backend/controllers"
 	_ "gcom-backend/docs"
 	"gcom-backend/util"
 	"log"
+	"os"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -28,6 +30,12 @@ import (
 
 func main() {
 	db := configs.Connect(false)
+	err := os.MkdirAll("db", 0755)  //Create db dir
+	err = os.MkdirAll("imgs", 0755) //Create images dir
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 
 	mp, err := configs.ConnectMissionPlanner("http://host.docker.internal:9000")
 	if err != nil {
@@ -79,6 +87,12 @@ func main() {
 	e.DELETE("/groundobject/:objectId", controllers.DeleteGroundObject)
 	e.DELETE("/groundobjects", controllers.DeleteGroundObjectBatch)
 	e.GET("/groundobjects", controllers.GetAllGroundObjects)
+
+	//Image Handling
+	e.POST("/image", controllers.UploadImage)
+	e.GET("/image/list", controllers.ListImages)
+	e.GET("/image/:filename", controllers.GetImage)
+	e.GET("/image/:filename/details", controllers.GetImageDetails)
 
 	//Websockets
 	e.Any("/socket.io/", controllers.WebsocketHandler())

--- a/main.go
+++ b/main.go
@@ -92,7 +92,6 @@ func main() {
 	e.POST("/image", controllers.UploadImage)
 	e.GET("/image/list", controllers.ListImages)
 	e.GET("/image/:filename", controllers.GetImage)
-	e.GET("/image/:filename/details", controllers.GetImageDetails)
 
 	//Websockets
 	e.Any("/socket.io/", controllers.WebsocketHandler())

--- a/models/image_model.go
+++ b/models/image_model.go
@@ -1,0 +1,10 @@
+package models
+
+type Image struct {
+	Timestamp int64   `json:"timestamp" gorm:"primaryKey" validate:"required" example:"1698544781" extensions:"x-order=1"`
+	Filename  string  `json:"filename" example:"1714898050.png" extensions:"x-order=2"`
+	Latitude  float64 `json:"lat" example:"49.267941" extensions:"x-order=3"`
+	Longitude float64 `json:"long" example:"-123.247360" extensions:"x-order=4"`
+	Altitude  float64 `json:"alt" example:"100.00" extensions:"x-order=5"`
+	Heading   float64 `json:"heading" example:"298.12" extensions:"x-order=6"`
+}

--- a/models/image_model.go
+++ b/models/image_model.go
@@ -1,10 +1,6 @@
 package models
 
 type Image struct {
-	Timestamp int64   `json:"timestamp" gorm:"primaryKey" validate:"required" example:"1698544781" extensions:"x-order=1"`
-	Filename  string  `json:"filename" example:"1714898050.png" extensions:"x-order=2"`
-	Latitude  float64 `json:"lat" example:"49.267941" extensions:"x-order=3"`
-	Longitude float64 `json:"long" example:"-123.247360" extensions:"x-order=4"`
-	Altitude  float64 `json:"alt" example:"100.00" extensions:"x-order=5"`
-	Heading   float64 `json:"heading" example:"298.12" extensions:"x-order=6"`
+	Timestamp int64  `json:"timestamp" gorm:"primaryKey" validate:"required" example:"1698544781" extensions:"x-order=1"`
+	Filename  string `json:"filename" example:"1714898050.png" extensions:"x-order=2"`
 }

--- a/models/migrate.go
+++ b/models/migrate.go
@@ -9,7 +9,7 @@ import "gorm.io/gorm"
 */
 
 func Migrate(db *gorm.DB) {
-	err := db.AutoMigrate(&Waypoint{}, &Drone{}, &GroundObject{})
+	err := db.AutoMigrate(&Waypoint{}, &Drone{}, &GroundObject{}, &Image{})
 	if err != nil {
 		panic(err)
 	}

--- a/responses/multple_response.go
+++ b/responses/multple_response.go
@@ -4,6 +4,6 @@ package responses
 //
 // @Description Describes a response with multiple waypoints
 type MultipleResponse[T any] struct {
-	Message   string            `json:"message" example:"Sample success message"`
-	Models []T `json:"waypoints"`
+	Message string `json:"message" example:"Sample success message"`
+	Models  []T    `json:"models"`
 }


### PR DESCRIPTION
added ODLC file handling and ground object structs

**Endpoints Added**
- Basic CRUD on GroundObjects
- POST `/image` - Uploads an image (for Camera people)
- GET `/image/list` - Lists all images on the server (images on server will all be timestamped)
- GET `/image/:filename` - Downloads an image based on the filename

I did not add telemetry data as there may be cases where you need to do some interpolation. You can grab telemetry data from the `/status` endpoints